### PR TITLE
To provide enough JVM Heap memory(>512MB) to Kkma, added -Xmx768m argume...

### DIFF
--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -30,4 +30,4 @@ def init_jvm(jvmpath=None):
     classpath = os.pathsep.join(f.format(*args) for f in folder_suffix)
 
     jvmpath = jvmpath or jpype.getDefaultJVMPath()
-    jpype.startJVM(jvmpath, '-Djava.class.path=%s' % classpath, '-ea')
+    jpype.startJVM(jvmpath, '-Djava.class.path=%s' % classpath, '-ea', '-Xmx768m')


### PR DESCRIPTION
...nt on jpype.startJVM() call

now Kkma works fine with Mac OS X 10.9
