### PR TITLE
Simplify, replace method to using equals

### DIFF
--- a/konlpy/java/src/kr/lucypark/jhannanum/comm/HannanumInterface.java
+++ b/konlpy/java/src/kr/lucypark/jhannanum/comm/HannanumInterface.java
@@ -2,7 +2,11 @@ package kr.lucypark.jhannanum.comm;
 
 /* Copyright 2014 Lucy Park <me@lucypark.kr> */
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 import kr.ac.kaist.swrc.jhannanum.comm.Eojeol;
 import kr.ac.kaist.swrc.jhannanum.comm.Sentence;
@@ -37,7 +41,7 @@ public class HannanumInterface {
 
     public String[] extractNoun(String phrase) throws ResultTypeException {
         if (phrase == null || Objects.equals(phrase, "") || phrase.length() == 0) {
-            return new String[] { "" };
+            return new String[]{""};
         }
         try {
             if (wfNoun == null) {

--- a/konlpy/java/src/kr/lucypark/jhannanum/comm/HannanumInterface.java
+++ b/konlpy/java/src/kr/lucypark/jhannanum/comm/HannanumInterface.java
@@ -2,9 +2,7 @@ package kr.lucypark.jhannanum.comm;
 
 /* Copyright 2014 Lucy Park <me@lucypark.kr> */
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import kr.ac.kaist.swrc.jhannanum.comm.Eojeol;
 import kr.ac.kaist.swrc.jhannanum.comm.Sentence;
@@ -19,7 +17,7 @@ public class HannanumInterface {
     private Workflow wfPos22 = null;
 
     public String morphAnalyzer(String phrase) {
-        if (phrase == null || phrase == "" || phrase.length() == 0) {
+        if (phrase == null || Objects.equals(phrase, "") || phrase.length() == 0) {
             return null;
         }
         try {
@@ -28,7 +26,7 @@ public class HannanumInterface {
                 wfMorph.activateWorkflow(false);
             }
             wfMorph.analyze(phrase);
-            return wfMorph.getResultOfDocument().toString();
+            return wfMorph.getResultOfDocument();
         } catch (Exception e) {
             e.printStackTrace();
             return null;
@@ -38,9 +36,8 @@ public class HannanumInterface {
     }
 
     public String[] extractNoun(String phrase) throws ResultTypeException {
-        if (phrase == null || phrase == "" || phrase.length() == 0) {
-            String[] tmp = new String[] { "" };
-            return tmp;
+        if (phrase == null || Objects.equals(phrase, "") || phrase.length() == 0) {
+            return new String[] { "" };
         }
         try {
             if (wfNoun == null) {
@@ -49,19 +46,17 @@ public class HannanumInterface {
             }
             wfNoun.analyze(phrase);
             LinkedList<Sentence> resultList = wfNoun.getResultOfDocument(new Sentence(0, 0, false));
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             for (Sentence s : resultList) {
                 Eojeol[] eojeolArray = s.getEojeols();
-                for (int i = 0; i < eojeolArray.length; i++) {
-                    if (eojeolArray[i].length > 0) {
-                        String[] morphemes = eojeolArray[i].getMorphemes();
-                        for (int j = 0; j < morphemes.length; j++) {
-                            list.add(morphemes[j]);
-                        }
+                for (Eojeol anEojeolArray : eojeolArray) {
+                    if (anEojeolArray.length > 0) {
+                        String[] morphemes = anEojeolArray.getMorphemes();
+                        Collections.addAll(list, morphemes);
                     }
                 }
             }
-            return list.toArray(new String[0]);
+            return list.toArray(new String[list.size()]);
         } catch (Exception e) {
             e.printStackTrace();
             return null;
@@ -71,7 +66,7 @@ public class HannanumInterface {
     }
 
     public String simplePos09(String phrase) {
-        if (phrase == null || phrase == "" || phrase.length() == 0) {
+        if (phrase == null || Objects.equals(phrase, "") || phrase.length() == 0) {
             return null;
         }
         try {
@@ -80,7 +75,7 @@ public class HannanumInterface {
                 wfPos09.activateWorkflow(false);
             }
             wfPos09.analyze(phrase);
-            return wfPos09.getResultOfDocument().toString();
+            return wfPos09.getResultOfDocument();
         } catch (Exception e) {
             e.printStackTrace();
             return null;
@@ -90,7 +85,7 @@ public class HannanumInterface {
     }
 
     public String simplePos22(String phrase) {
-        if (phrase == null || phrase == "" || phrase.length() == 0) {
+        if (phrase == null || Objects.equals(phrase, "") || phrase.length() == 0) {
             return null;
         }
         try {
@@ -99,7 +94,7 @@ public class HannanumInterface {
                 wfPos22.activateWorkflow(false);
             }
             wfPos22.analyze(phrase);
-            return wfPos22.getResultOfDocument().toString();
+            return wfPos22.getResultOfDocument();
         } catch (Exception e) {
             e.printStackTrace();
             return null;
@@ -117,8 +112,8 @@ public class HannanumInterface {
 
         // Test extractNoun
         String[] nouns = hi.extractNoun("");
-        for (int i = 0; i < nouns.length; i++) {
-            System.out.println(nouns[i]);
+        for (String noun : nouns) {
+            System.out.println(noun);
         }
 
         // Test SimplePOS
@@ -130,6 +125,5 @@ public class HannanumInterface {
 
     private void closeWorkFlow(Workflow workflow) {
         workflow.close();
-        workflow = null;
     }
 }


### PR DESCRIPTION
String을 비교할 때 `==`을 사용하던 것을 `equals`를 호출하도록 변경하였습니다.
`for`문을 `foreach`문을 사용하도록 변경하였습니다.
konlpy는 JDK 1.7 이상 설치를 요구하고 있기 때문에 `new ArrayList<String>()`을 `new ArrayList<>()`으로 변경하였습니다.
`list.toArray(new String[0])`의 경우 list에 element가 존재할 경우 array의 크기가 리스트보다 작아서 array를 항상 다시 생성합니다. 이를 `list.toArray(new String[list.size()])` array를 list 크기만큼 만들어서 전달하도록 변경하였습니다.
for 문을 돌면서 `list.add(morphemes[j])` list에 element를 추가하던 구문을 `Collections.addAll(list, morphemes)`로 변경하고 for 문을 제거하였습니다.