### PR TITLE
Update mecab.sh

### DIFF
--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -42,6 +42,7 @@ cd /tmp
 curl -LO https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-1.6.1-20140814.tar.gz
 tar zxfv mecab-ko-dic-1.6.1-20140814.tar.gz
 cd mecab-ko-dic-1.6.1-20140814
+./autogen.sh
 ./configure
 sudo ldconfig
 make


### PR DESCRIPTION
autogen.sh을 실행하지 않고 configure을 하게 되면 AM_INIT_AUTOMAKE command not found 에러가 나서 빌드가 실패하는 경우가 있습니다. (우분투 14.04에서 확인)
