### PR TITLE
'global name 'tagger' is not defined' 버그 수정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
     - "3.4"
 
 before_install:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -r requirements.txt --use-mirrors; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -r requirements-py3.txt --use-mirrors; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -r requirements.txt; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -r requirements-py3.txt; fi
     - pip install coveralls
     - pip install pytest-cov
 

--- a/konlpy/tag/__init__.py
+++ b/konlpy/tag/__init__.py
@@ -4,8 +4,5 @@ import warnings
 from ._hannanum import Hannanum
 from ._kkma import Kkma
 from ._komoran import Komoran
-try:
-    from ._mecab import Mecab
-except ImportError:
-    pass
+from ._mecab import Mecab
 from ._twitter import Twitter

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -5,7 +5,7 @@ import sys
 
 try:
     from MeCab import Tagger
-except ImportError:
+except ImportError as e:
     pass
 from .. import utils
 
@@ -103,3 +103,6 @@ class Mecab():
             self.tagset = utils.read_json('%s/data/tagset/mecab.json' % utils.installpath)
         except RuntimeError:
             raise Exception('Invalid MeCab dictionary path: "%s"\nInput the correct path when initiializing class: "Mecab(\'/some/dic/path\')"' % dicpath)
+        except NameError as e:
+            message = "%s. Perhaps you haven't installed MeCab and it's dependencies. See this link. http://konlpy.org/en/latest/install/" % e
+            raise NameError(message)

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -48,13 +48,9 @@ make
 sudo sh -c 'echo "dicdir=/usr/local/lib/mecab/dic/mecab-ko-dic" > /usr/local/etc/mecabrc'
 sudo make install
 
-# install mecab-python
-cd /tmp
-git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
-cd mecab-python-0.996
-
-python setup.py build
-sudo python setup.py install
-# TODO: check if python3 is installed
-python3 setup.py build
-sudo python3 setup.py install
+if python -c 'import sys; sys.exit(1 if sys.hexversion<0x03000000 else 0)'
+then
+  pip3 install mecab-python3==0.7
+else
+  pip install mecab-python===0.996
+fi


### PR DESCRIPTION
MeCab을 설치하지 않고 konlpy에서 Mecab을 이용할 경우 발생하는 문제를 수정했습니다. 크게 두 가지 문제가 생기는데,
1. `global name 'tagger' is not defined` 라는 에러 메시지를 보여줍니다. 이 메시지만으로 MeCab 문제라고 판단하기는 어려우므로, 보다 더 직관적인 메시지로 수정할 필요가 있습니다.
2. [Installation](http://konlpy.org/en/v0.4.4/install/) 메뉴얼에 나온대로 `bash <(curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh)` 을 실행해도 MeCab이 설치되지 않습니다. 정확히는 [scripts/mecab.sh](https://github.com/shaynekang/konlpy/blob/f3ebe91c017a6749ab939804426dc24d29fb525e/scripts/mecab.sh) 내에서 [커스터마이즈한 mecab-python](https://bitbucket.org/eunjeon/mecab-python-0.996.git) 을 설치하는데, 이 패키지를 konlpy에서 정상적으로 인식하지 못하는 것 같습니다.

해결 방법은 다음과 같습니다.
1. `global name 'tagger' is not defined` 뒤에 부연 설명을 붙여주었습니다. 이제는 다음과 같은 메시지를 출력합니다.
   
   ``` python
   Python 2.7.11 (default, May  5 2016, 15:27:40) 
   [GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)] on darwin
   Type "help", "copyright", "credits" or "license" for more information.
   >>> from konlpy.tag import Mecab; Mecab()
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "konlpy/tag/_mecab.py", line 108, in __init__
       raise NameError(message)
   NameError: global name 'Tagger' is not defined. Perhaps you haven't installed MeCab and it's dependencies. See this link. http://konlpy.org/en/latest/install/
   ```
2. [scripts/mecab.sh](https://github.com/shaynekang/konlpy/blob/ad9ba51582b2cda80d7c54b19133ca40f9f28eaa/scripts/mecab.sh) 에서 커스터마이즈 하지 않은 mecab-python을 설치합니다. 단 dependency 문제가 생길 수 있으므로, 문제가 생기지 않는 mecab-python의 현재 버전(Python2: 0.996, Python3: 0.7)으로 고정해 두었습니다.

2번에서 버전을 고정한 부분은 차후에 문제가 생길 수 있습니다. 가령 다른 패키지에서 mecab-python===0.996(또는 mecab-python3==0.7)이 아닌 다른 버전을 사용하면 문제가 생길 것입니다. 이 부분은 장기적인 관점에서 해결하면 될 것 같습니다. (e.g 버전을 fix하지 않되, mecab-python의 모든 버전에 대한 회귀 테스트를 돌린 후 문제가 생기면 이를 수정하거나 해당 버전을 deprecated 하기)
