### PR TITLE
`Komoran` also supports to set user dictionary and fwdic.

### DIFF
--- a/konlpy/java/src/kr/lucypark/komoran/KomoranInterface.java
+++ b/konlpy/java/src/kr/lucypark/komoran/KomoranInterface.java
@@ -16,6 +16,18 @@ public class KomoranInterface {
 			komoran = new Komoran(dicpath);
 		}
 	}
+
+	public void setUserDic(String user_dic){
+		if(komoran != null){
+            komoran.setUserDic(user_dic);
+        }
+	}
+
+	public void setFWDic(String fwd_file){
+		if(komoran != null){
+            komoran.setFWDic(fwd_file);
+        }
+	}
 	
     public List<ArrayList<String>> analyzeMorphs(String phrase, String dicpath) {
 		initKomoran(dicpath);

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -49,10 +49,16 @@ class Komoran():
     :param dicpath: The path of dictionary files. The KOMORAN system dictionary is loaded by default.
     """
 
-    def pos(self, phrase, flatten=True):
+    def pos(self, phrase, flatten=True, user_dic=None, fwd_file=None):
         """POS tagger.
 
         :param flatten: If False, preserves eojeols."""
+
+        if user_dic:
+            self.jki.setUserDic(user_dic)
+
+        if fwd_file:
+            self.jki.setFWDic(fwd_file)
 
         if sys.version_info[0] < 3:
             result = self.jki.analyzeMorphs(phrase, self.dicpath)


### PR DESCRIPTION
Komoran has been supporting to set user dictionary, but in konlpy did not, so this small patches will be enable to use user dictionary and fwdic also in komoran.

```
>  lb = Komoran()
> lb.pos(pharse, user_dic='/tmp/user_dic.csv', fwd_file='/tmp/fwdic.csv')
```
Thanks.