### PR TITLE
Add join parameter

### DIFF
--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -16,9 +16,12 @@ __all__ = ['Hannanum']
 tag_re = '(.+?\\/\\w+)\\+?'
 
 
-def parse(result, flatten=False):
-    def parse_opt(opt):
-        return [tuple(u.rsplit('/', 1)) for u in re.findall(tag_re, opt.strip())]
+def parse(result, flatten=False, join=False):
+    def parse_opt(opt, join=False):
+        if join:
+            return [u for u in re.findall(tag_re, opt.strip())]
+        else:
+            return [tuple(u.rsplit('/', 1)) for u in re.findall(tag_re, opt.strip())]
 
     if not result:
         return []
@@ -28,10 +31,10 @@ def parse(result, flatten=False):
     parts = utils.partition(elems, index)
 
     if flatten:
-        return sum([parse_opt(opt) for part in parts
+        return sum([parse_opt(opt, join=join) for part in parts
                     for opt in list(filter(None, part))[1:]], [])
     else:
-        return [[parse_opt(opt) for opt in list(filter(None, part))[1:]]
+        return [[parse_opt(opt, join=join) for opt in list(filter(None, part))[1:]]
                 for part in parts]
 
 
@@ -71,13 +74,15 @@ class Hannanum():
         result = self.jhi.morphAnalyzer(phrase)
         return parse(result)
 
-    def pos(self, phrase, ntags=9, flatten=True):
+    def pos(self, phrase, ntags=9, flatten=True, join=False):
         """POS tagger.
 
         This tagger is HMM based, and calculates the probability of tags.
 
         :param ntags: The number of tags. It can be either 9 or 22.
-        :param flatten: If False, preserves eojeols."""
+        :param flatten: If False, preserves eojeols.
+        :param join: If True, returns joined sets of morph and tag.
+        """
 
         if ntags == 9:
             result = self.jhi.simplePos09(phrase)
@@ -85,7 +90,7 @@ class Hannanum():
             result = self.jhi.simplePos22(phrase)
         else:
             raise Exception('ntags in [9, 22]')
-        return parse(result, flatten=flatten)
+        return parse(result, flatten=flatten, join=join)
 
     def nouns(self, phrase):
         """Noun extractor."""

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -46,10 +46,12 @@ class Kkma():
         if not nouns: return []
         return [nouns.get(i).getString() for i in range(nouns.size())]
 
-    def pos(self, phrase, flatten=True):
+    def pos(self, phrase, flatten=True, join=False):
         """POS tagger.
 
-        :param flatten: If False, preserves eojeols."""
+        :param flatten: If False, preserves eojeols.
+        :param join: If True, returns joined sets of morph and tag.
+        """
 
         sentences = self.jki.morphAnalyzer(phrase)
         morphemes = []
@@ -63,10 +65,17 @@ class Kkma():
                 if flatten:
                     for k in range(eojeol.size()):
                         morpheme = eojeol.get(k)
-                        morphemes.append((morpheme.getString(), morpheme.getTag()))
+                        if join:
+                            morphemes.append(morpheme.getString() + '/' + morpheme.getTag())
+                        else:
+                            morphemes.append((morpheme.getString(), morpheme.getTag()))
                 else:
-                    morphemes.append([(eojeol.get(k).getString(), eojeol.get(k).getTag())
-                                     for k in range(eojeol.size())])
+                    if join:
+                        morphemes.append([eojeol.get(k).getString() + '/' + eojeol.get(k).getTag()
+                                         for k in range(eojeol.size())])
+                    else:
+                        morphemes.append([(eojeol.get(k).getString(), eojeol.get(k).getTag())
+                                         for k in range(eojeol.size())])
 
         return morphemes
 

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -15,14 +15,20 @@ from .. import internals
 __all__ = ['Komoran']
 
 
-def parse(result, flatten):
-    def _parse(token):
-        return [tuple(s[1:].rsplit('/', 1)) for s in re.findall('\+.+?/[A-Z]+', token)]
+def parse(result, flatten, join=False):
+    def _parse(token, join=False):
+        if join:
+            return [s[1:] for s in re.findall('\+.+?/[A-Z]+', token)]
+        else:
+            return [tuple(s[1:].rsplit('/', 1)) for s in re.findall('\+.+?/[A-Z]+', token)]
 
     if sys.version_info[0] < 3:
-        parsed = [[tuple(r.rsplit('/', 1)) for r in sublist] for sublist in result]
+        if join:
+            parsed = [[r for r in sublist] for sublist in result]
+        else:
+            parsed = [[tuple(r.rsplit('/', 1)) for r in sublist] for sublist in result]
     else:
-        parsed = [_parse(i) for i in result[1:-1].split(', ')]
+        parsed = [_parse(i, join=join) for i in result[1:-1].split(', ')]
 
     if flatten:
         return sum(parsed, [])
@@ -49,17 +55,19 @@ class Komoran():
     :param dicpath: The path of dictionary files. The KOMORAN system dictionary is loaded by default.
     """
 
-    def pos(self, phrase, flatten=True):
+    def pos(self, phrase, flatten=True, join=False):
         """POS tagger.
 
-        :param flatten: If False, preserves eojeols."""
+        :param flatten: If False, preserves eojeols.
+        :param join: If True, returns joined sets of morph and tag.
+        """
 
         if sys.version_info[0] < 3:
             result = self.jki.analyzeMorphs(phrase, self.dicpath)
         else:
             result = self.jki.analyzeMorphs3(phrase, self.dicpath).toString()
 
-        return parse(result, flatten)
+        return parse(result, flatten, join=join)
 
     def nouns(self, phrase):
         """Noun extractor."""

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -24,13 +24,16 @@ attrs = ['tags',        # 품사 태그
          'indexed']     # 인덱스 표현
 
 
-def parse(result, allattrs=False):
-    def split(elem):
+def parse(result, allattrs=False, join=False):
+    def split(elem, join=False):
         if not elem: return ('', 'SY')
         s, t = elem.split('\t')
-        return (s, t.split(',', 1)[0])
+        if join:
+            return s + '/' + t.split(',', 1)[0]
+        else:
+            return (s, t.split(',', 1)[0])
 
-    return [split(elem) for elem in result.splitlines()[:-1]]
+    return [split(elem, join=join) for elem in result.splitlines()[:-1]]
 
 
 class Mecab():
@@ -64,26 +67,27 @@ class Mecab():
     """
 
     # TODO: check whether flattened results equal non-flattened
-    def pos(self, phrase, flatten=True):
+    def pos(self, phrase, flatten=True, join=False):
         """POS tagger.
 
         :param flatten: If False, preserves eojeols.
+        :param join: If True, returns joined sets of morph and tag.
         """
 
         if sys.version_info[0] < 3:
             phrase = phrase.encode('utf-8')
             if flatten:
                 result = self.tagger.parse(phrase).decode('utf-8')
-                return parse(result)
+                return parse(result, join=join)
             else:
-                return [parse(self.tagger.parse(eojeol).decode('utf-8'))
+                return [parse(self.tagger.parse(eojeol).decode('utf-8'), join=join)
                         for eojeol in phrase.split()]
         else:
             if flatten:
                 result = self.tagger.parse(phrase)
-                return parse(result)
+                return parse(result, join=join)
             else:
-                return [parse(self.tagger.parse(eojeol).decode('utf-8'))
+                return [parse(self.tagger.parse(eojeol).decode('utf-8'), join=join)
                         for eojeol in phrase.split()]
 
     def morphs(self, phrase):

--- a/konlpy/tag/_twitter.py
+++ b/konlpy/tag/_twitter.py
@@ -34,7 +34,7 @@ class Twitter():
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
     """
 
-    def pos(self, phrase, norm=False, stem=False):
+    def pos(self, phrase, norm=False, stem=False, join=False):
         """POS tagger.
         In contrast to other classes in this subpackage,
         this POS tagger doesn't have a `flatten` option,
@@ -43,13 +43,17 @@ class Twitter():
 
         :param norm: If True, normalize tokens.
         :param stem: If True, stem tokens.
+        :param join: If True, returns joined sets of morph and tag.
         """
 
         tokens = self.jki.tokenize(
                     phrase,
                     jpype.java.lang.Boolean(norm),
                     jpype.java.lang.Boolean(stem)).toArray()
-        return [tuple(t.rsplit('/', 1)) for t in tokens]
+        if join:
+            return [t for t in tokens]
+        else:
+            return [tuple(t.rsplit('/', 1)) for t in tokens]
 
     def nouns(self, phrase):
         """Noun extractor."""

--- a/test/test_hannanum.py
+++ b/test/test_hannanum.py
@@ -68,3 +68,13 @@ def test_hannanum_pos_22(hannanum_instance, string):
          (u'\uac00', u'PX'),
          (u'\uc790', u'EC'),
          (u'!', u'SF')]
+
+def test_hannanum_pos_join(hannanum_instance, string):
+    assert hannanum_instance.pos(string, join=True) ==\
+        [u'\uaf43\uac00\ub9c8/N',
+         u'\ud0c0/P',
+         u'\uace0/E',
+         u'\uac15\ub0a8/N',
+         u'\uac00/P',
+         u'\uc790/E',
+         u'!/S']

--- a/test/test_kkma.py
+++ b/test/test_kkma.py
@@ -35,6 +35,14 @@ def test_kkma_pos(kkma_instance, string):
          (u'\uac00\uc790', u'NNG'),
          (u'!', u'SF')]
 
+def test_kkma_pos_join(kkma_instance, string):
+    assert kkma_instance.pos(string, join=True) ==\
+        [u'\uaf43\uac00\ub9c8/NNG',
+         u'\ud0c0\uace0/NNG',
+         u'\uac15\ub0a8/NNG',
+         u'\uac00\uc790/NNG',
+         u'!/SF']
+
 def test_kkma_sentences(kkma_instance, string):
     assert kkma_instance.sentences(string) ==\
         [u'\uaf43\uac00\ub9c8 \ud0c0\uace0 \uac15\ub0a8 \uac00\uc790!']

--- a/test/test_komoran.py
+++ b/test/test_komoran.py
@@ -34,3 +34,13 @@ else:
              (u'\uac00', u'VV'),
              (u'\uc790', u'EF'),
              (u'!', u'SF')]
+
+    def test_komoran_pos_join(komoran_instance, string):
+        assert komoran_instance.pos(string, join=True) ==\
+            [u'\uaf43\uac00\ub9c8/NNG',
+             u'\ud0c0/VV',
+             u'\uace0/EC',
+             u'\uac15\ub0a8/NNP',
+             u'\uac00/VV',
+             u'\uc790/EF',
+             u'!/SF']

--- a/test/test_mecab.py
+++ b/test/test_mecab.py
@@ -24,6 +24,16 @@ def test_mecab_pos_43(mecab_instance, string):
          (u'\uc790', u'EF'),
          (u'!', u'SF')]
 
+def test_mecab_pos_join(mecab_instance, string):
+    assert mecab_instance.pos(string, join=True) ==\
+        [u'\uaf43\uac00\ub9c8/NNG',
+         u'\ud0c0/VV',
+         u'\uace0/EC',
+         u'\uac15\ub0a8/NNP',
+         u'\uac00/VV',
+         u'\uc790/EF',
+         u'!/SF']
+
 def test_mecab_morphs(mecab_instance, string):
     assert mecab_instance.morphs(string) ==\
         [u'\uaf43\uac00\ub9c8',

--- a/test/test_twitter.py
+++ b/test/test_twitter.py
@@ -33,6 +33,10 @@ def test_tkorean_pos_3(tkorean_instance, string):
     assert tkorean_instance.pos(string, stem=True, norm=True) ==\
         [(u'\uaf43', u'Noun'), (u'\uac00\ub9c8', u'Noun'), (u'\ud0c0\uace0', u'Noun'), (u'\uac15\ub0a8', u'Noun'), (u'\uac00\ub098', u'Noun'), (u'\uc694', u'Josa'), (u'\u314b\u314b', u'KoreanParticle')]
 
+def test_tkorean_pos_join(tkorean_instance, string):
+    assert tkorean_instance.pos(string, join=True) ==\
+        [u'\uaf43/Noun', u'\uac00\ub9c8/Noun', u'\ud0c0\uace0/Noun', u'\uac15\ub0a8/Noun', u'\uac00\ub098/Noun', u'\uc6ac/Noun', u'\u314b\u314b\u314b\u314b/KoreanParticle']
+
 def test_tkorean_nouns(tkorean_instance, string):
     assert tkorean_instance.nouns(string) ==\
         [u'\uaf43', u'\uac00\ub9c8', u'\ud0c0\uace0', u'\uac15\ub0a8', u'\uac00\ub098', u'\uc6ac']


### PR DESCRIPTION
This pull request is about issue #75 .
Developed parts are as follows.
- Development target
    - konlpy/tag/_hannanum
        - Add join parameter at parse function (default : False)
        - Add join parameter at pos function (default: False)
    - konlpy/tag/_kkma
        - Add join parameter at pos function (default: False)
    - konlpy/tag/_komoran
        - Add join parameter at parse function (default : False)
            - Add join parameter at _parse function (default : False)
        - Add join parameter at pos function (default: False)
    - konlpy/tag/_mecab
        - Add join parameter at parse function (default : False)
            - Add join parameter at split function (default : False)
        - Add join parameter at pos function (default: False)
    - konlpy/tag/_twitter
        - Add join parameter at pos function (default: False)
- Test target
    - Cover pos functions of all the development targets.
- Documentation
    - Add join parameter description at pos functinos of all the development targets.

@e9t Thanks!