### PR TITLE
Edit directory explicitly: automake/mecab-ko-dic

### DIFF
--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -42,16 +42,16 @@ sudo make install
 # TODO: if not [automake --version]
 cd /tmp
 curl -LO http://ftpmirror.gnu.org/automake/automake-1.11.tar.gz
-tar -zxvf automake-*.tar.gz
-cd automake-*
+tar -zxvf automake-1.11.tar.gz
+cd automake-1.11
 ./configure
 make
 sudo make install
 
 cd /tmp
 curl -LO https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.0.1-20150920.tar.gz
-tar -zxvf mecab-ko-dic-2.0.1-*.tar.gz
-cd mecab-ko-dic-2.0.1-*
+tar -zxvf mecab-ko-dic-2.0.1-20150920.tar.gz
+cd mecab-ko-dic-2.0.1-20150920
 ./autogen.sh
 ./configure
 make


### PR DESCRIPTION
zsh does not understand `cd automake-*` and outputs `cd: string not in pwd: automake-1.11`

![image](https://user-images.githubusercontent.com/18069263/30518866-1f0c21ba-9bc4-11e7-97a1-e5056f2a055e.png)

`cd automake-1.11` works

![image](https://user-images.githubusercontent.com/18069263/30518872-4f9b83ac-9bc4-11e7-8755-002068f2e5c7.png)

