### PR TITLE
fix error permission denied

### DIFF
--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -68,6 +68,6 @@ python setup.py install
 
 if hash "python3" &>/dev/null
 then
-    python3 setup.py build
-    python3 setup.py install
+    sudo python3 setup.py build
+    sudo python3 setup.py install
 fi


### PR DESCRIPTION
There is a problem that mecab does not install properly for Linux permissions problem. It can fix the problem by add sudo in mecab.sh.