### PR TITLE
Fix #199

### DIFF
--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -12,7 +12,7 @@ except ImportError:
 from konlpy import utils
 
 
-def init_jvm(jvmpath=None):
+def init_jvm(jvmpath=None, max_heap_size=1024):
     """Initializes the Java virtual machine (JVM).
 
     :param jvmpath: The path of the JVM. If left empty, inferred by :py:func:`jpype.getDefaultJVMPath`.
@@ -62,6 +62,6 @@ def init_jvm(jvmpath=None):
     if jvmpath:
         jpype.startJVM(jvmpath, '-Djava.class.path=%s' % classpath,
                                 '-Dfile.encoding=UTF8',
-                                '-ea', '-Xmx1024m')
+                                '-ea', '-Xmx{}m'.format(max_heap_size))
     else:
         raise ValueError("Please specify the JVM path.")

--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -16,7 +16,7 @@ def init_jvm(jvmpath=None, max_heap_size=1024):
     """Initializes the Java virtual machine (JVM).
 
     :param jvmpath: The path of the JVM. If left empty, inferred by :py:func:`jpype.getDefaultJVMPath`.
-    :param max_heap_size: Maximum memory usage limitation (Megabyte). Default is 1024 (1Gb). If you set this value too small, you may got out of memory. We recommend that you set it 1024 ~ 2048 or more at least. However, if this value is too large, you may see inefficient memory usage.
+    :param max_heap_size: Maximum memory usage limitation (Megabyte). Default is 1024 (1GB). If you set this value too small, you may got out of memory. We recommend that you set it 1024 ~ 2048 or more at least. However, if this value is too large, you may see inefficient memory usage.
 
     """
 

--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -16,6 +16,7 @@ def init_jvm(jvmpath=None, max_heap_size=1024):
     """Initializes the Java virtual machine (JVM).
 
     :param jvmpath: The path of the JVM. If left empty, inferred by :py:func:`jpype.getDefaultJVMPath`.
+    :param max_heap_size: Maximum memory usage limitation (Megabyte). Default is 1024 (1Gb). If you set this value too small, you may got out of memory. We recommend that you set it 1024 ~ 2048 or more at least. However, if this value is too large, you may see inefficient memory usage.
 
     """
 

--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -60,6 +60,7 @@ class Hannanum():
         [('웃', 'P'), ('으면', 'E'), ('더', 'M'), ('행복', 'N'), ('하', 'X'), ('ㅂ니다', 'E'), ('!', 'S')]
 
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
+    :param max_heap_size: The path of the JVM passed to :py:func:`.init_jvm`.
     """
 
     def analyze(self, phrase):

--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -102,9 +102,9 @@ class Hannanum():
 
         return [s for s, t in self.pos(phrase)]
 
-    def __init__(self, jvmpath=None):
+    def __init__(self, jvmpath=None, max_heap_size=1024):
         if not jpype.isJVMStarted():
-            jvm.init_jvm(jvmpath)
+            jvm.init_jvm(jvmpath, max_heap_size)
 
         jhannanumJavaPackage = jpype.JPackage('kr.lucypark.jhannanum.comm')
         HannanumInterfaceJavaClass = jhannanumJavaPackage.HannanumInterface

--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -60,7 +60,7 @@ class Hannanum():
         [('웃', 'P'), ('으면', 'E'), ('더', 'M'), ('행복', 'N'), ('하', 'X'), ('ㅂ니다', 'E'), ('!', 'S')]
 
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
-    :param max_heap_size: The path of the JVM passed to :py:func:`.init_jvm`.
+    :param max_heap_size: Maximum memory usage limitation (Megabyte) :py:func:`.init_jvm`.
     """
 
     def analyze(self, phrase):

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -89,9 +89,9 @@ class Kkma():
         if not sentences: return []
         return [sentences.get(i).getSentence() for i in range(sentences.size())]
 
-    def __init__(self, jvmpath=None):
+    def __init__(self, jvmpath=None, max_heap_size=1024):
         if not jpype.isJVMStarted():
-            jvm.init_jvm(jvmpath)
+            jvm.init_jvm(jvmpath, max_heap_size)
 
         kkmaJavaPackage = jpype.JPackage('kr.lucypark.kkma')
         KkmaInterfaceJavaClass = kkmaJavaPackage.KkmaInterface

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -35,7 +35,7 @@ class Kkma():
         There are reports that ``Kkma()`` is weak for long strings with no spaces between words. See issue :issue:`73` for details.
 
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
-    :param max_heap_size: The path of the JVM passed to :py:func:`.init_jvm`.
+    :param max_heap_size: Maximum memory usage limitation (Megabyte) :py:func:`.init_jvm`.
     """
 
     def nouns(self, phrase):

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -35,6 +35,7 @@ class Kkma():
         There are reports that ``Kkma()`` is weak for long strings with no spaces between words. See issue :issue:`73` for details.
 
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
+    :param max_heap_size: The path of the JVM passed to :py:func:`.init_jvm`.
     """
 
     def nouns(self, phrase):

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -85,9 +85,9 @@ class Komoran():
 
         return [s for s, t in self.pos(phrase)]
 
-    def __init__(self, jvmpath=None, userdic=None, modelpath=None):
+    def __init__(self, jvmpath=None, userdic=None, modelpath=None, max_heap_size=1024):
         if not jpype.isJVMStarted():
-            jvm.init_jvm(jvmpath)
+            jvm.init_jvm(jvmpath, max_heap_size)
 
         if modelpath:
             self.modelpath = modelpath

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -47,7 +47,7 @@ class Komoran():
 
         If a particular POS is not assigned for a token or phrase, it will be tagged as NNP.
     :param modelpath: The path to the Komoran HMM model.
-    :param max_heap_size: The path of the JVM passed to :py:func:`.init_jvm`.
+    :param max_heap_size: Maximum memory usage limitation (Megabyte) :py:func:`.init_jvm`.
     """
 
     def pos(self, phrase, flatten=True, join=False):

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -47,6 +47,7 @@ class Komoran():
 
         If a particular POS is not assigned for a token or phrase, it will be tagged as NNP.
     :param modelpath: The path to the Komoran HMM model.
+    :param max_heap_size: The path of the JVM passed to :py:func:`.init_jvm`.
     """
 
     def pos(self, phrase, flatten=True, join=False):

--- a/konlpy/tag/_okt.py
+++ b/konlpy/tag/_okt.py
@@ -81,9 +81,9 @@ class Okt():
 
         return [p for p in self.jki.phrases(phrase).toArray()]
 
-    def __init__(self, jvmpath=None):
+    def __init__(self, jvmpath=None, max_heap_size=1024):
         if not jpype.isJVMStarted():
-            jvm.init_jvm(jvmpath)
+            jvm.init_jvm(jvmpath, max_heap_size)
 
         oktJavaPackage = jpype.JPackage('kr.lucypark.okt')
         OktInterfaceJavaClass = oktJavaPackage.OktInterface

--- a/konlpy/tag/_okt.py
+++ b/konlpy/tag/_okt.py
@@ -42,6 +42,7 @@ class Okt():
         [('이', 'Determiner'), ('것', 'Noun'), ('도', 'Josa'), ('되다', 'Verb'), ('ㅋㅋ', 'KoreanParticle')]
 
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
+    :param max_heap_size: Maximum memory usage limitation (Megabyte) :py:func:`.init_jvm`.
     """
 
     def pos(self, phrase, norm=False, stem=False, join=False):


### PR DESCRIPTION
jvm 구동 시 최대 메모리 사용량 제약을 각 tagger 의 argument 로 넣어뒀습니다.