### PR TITLE
Ignore empty sentence

### DIFF
--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -63,6 +63,8 @@ class Komoran():
             return morphemes
 
         for sentence in sentences:
+            if not sentence:
+                continue
             result = self.jki.analyze(sentence).getTokenList()
             result = [(token.getMorph(), token.getPos()) for token in result]
 


### PR DESCRIPTION
phrase 를 sentence 로 나눌 때 split('\n') 을 이용한 결과, 다음과 같이 마지막에 line separator 가 포함된 문장에서 empty sentence 가 만들어집니다.

'예문 입니다\n'.split('\n') --> ['예문 입니다', '']

Komoran 에서 empty str 이 input 으로 들어가면 null point exception 이 발생하기 때문에 문장이 비어있으면 이를 무시하는 부분을 추가했습니다.

