### PR TITLE
Add methods to Mecab class for pickling

### DIFF
--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -110,3 +110,13 @@ class Mecab():
             raise Exception('The MeCab dictionary does not exist at "%s". Is the dictionary correctly installed?\nYou can also try entering the dictionary path when initializing the Mecab class: "Mecab(\'/some/dic/path\')"' % dicpath)
         except NameError:
             raise Exception('Install MeCab in order to use it: http://konlpy.org/en/latest/install/')
+
+    def __setstate__(self, state):
+        """just reinitialize."""
+
+        self.__init__(*state['args'])
+
+    def __getstate__(self):
+        """store arguments."""
+
+        return {'args': self.args}


### PR DESCRIPTION
사이킷런 0.19 버전까지 Mecab 클래스를 사용할 때 GridSearchCV의 n_jobs를 1 이상으로 설정해 여러개의 코어를 사용할 수 있었습니다. 사이킷런 0.20 버전부터는 피클링에서 오류가 발생합니다.(https://github.com/rickiepark/introduction_to_ml_with_python/issues/1)
아마도 사이킷런 0.20에서 새로 바뀐 joblib 0.12 버전 때문인 것 같습니다.(https://github.com/scikit-learn/scikit-learn/pull/11741)

간단히 상태를 관리하는 메서드를 추가해 해결했습니다.(https://stackoverflow.com/questions/9310053/how-to-make-my-swig-extension-module-work-with-pickle, https://github.com/rickiepark/introduction_to_ml_with_python/blob/master/07-konlpy.ipynb)

잘못된 점이 있으면 알려 주세요.
감사합니다! :)