### PR TITLE
Proper lxml version in requirements file

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -2,4 +2,4 @@ JPype1-py3>=0.5.5.1
 colorama
 tweepy
 beautifulsoup4==4.6.0
-lxml==4.1.0
+lxml>=4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ JPype1>=0.5.7
 colorama
 tweepy
 beautifulsoup4==4.6.0
-lxml==4.1.0
+lxml>=4.1.0


### PR DESCRIPTION
Current `lxml` is pinned to 4.1.0 which causes a problem when pip installing from the requirements file.