### PR TITLE
async is a keyword in Python 3.7

### DIFF
--- a/konlpy/stream/twitter.py
+++ b/konlpy/stream/twitter.py
@@ -216,7 +216,7 @@ class TwitterStreamer(BaseStreamer):
     def job(self):
         # FIXME: argument named "async" cannot be used in python3.7
         try:
-            self.streamer.filter(track=self.word_list, async=self.is_async)
+            self.streamer.filter(track=self.word_list, is_async=self.is_async)
         except ValueError:
             raise ValueError("Please provide decent access token, secret, consumer key and secret")
 

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,5 +1,0 @@
-JPype1-py3>=0.5.5.1
-colorama
-tweepy>=3.7.0
-beautifulsoup4==4.6.0
-lxml>=4.1.0

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,5 +1,5 @@
 JPype1-py3>=0.5.5.1
 colorama
-tweepy
+tweepy>=3.7.0
 beautifulsoup4==4.6.0
 lxml==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 JPype1>=0.5.7
 colorama
-tweepy
+tweepy>=3.7.0
 beautifulsoup4==4.6.0
 lxml==4.1.0


### PR DESCRIPTION
`async` is a keyword in python 3.7 but is now used in tweepy streamer.
Upstream has already changed this to handle the async keyword. Since `tweepy` is not pinned in the requirements file, changing the name of the argument should suffice.