### PR TITLE
Fix google trends streamer

### DIFF
--- a/konlpy/stream/google_trend.py
+++ b/konlpy/stream/google_trend.py
@@ -161,7 +161,9 @@ class GoogleTrendStreamer(BaseStreamer):
             if(trend['date'] == target_date):
                 return trend['trendingSearches'], trend['date']
 
-        return trends_list[0]['trendingSearches'], trends_list[0]['date']  # default, most recently
+        if trends_list:
+            return trends_list[0]['trendingSearches'], trends_list[0]['date']  # default, most recently
+        return [], []
 
 
 def main():


### PR DESCRIPTION
Current google trends streamer does not gracefully handle empty responses. This is an ugly hack to workaround the problem.