### PR TITLE
Modify JPype version to 0.7.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
     - "3.6"
 
 before_install:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -r requirements.txt; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -r requirements-py3.txt; fi
+    - pip install -r requirements.txt
     - pip install coveralls
     - pip install pytest-cov
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include requirements.txt
-include requirements-py3.txt
 recursive-include konlpy/data *
 recursive-include konlpy/java *.class *.jar *.json
 recursive-include konlpy/java/data *

--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -63,6 +63,7 @@ def init_jvm(jvmpath=None, max_heap_size=1024):
     if jvmpath:
         jpype.startJVM(jvmpath, '-Djava.class.path=%s' % classpath,
                                 '-Dfile.encoding=UTF8',
-                                '-ea', '-Xmx{}m'.format(max_heap_size))
+                                '-ea', '-Xmx{}m'.format(max_heap_size),
+                                convertStrings=True)
     else:
         raise ValueError("Please specify the JVM path.")

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,5 +1,0 @@
-JPype1-py3>=0.5.5.1
-colorama
-tweepy
-beautifulsoup4==4.6.0
-lxml==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-JPype1>=0.5.7
+JPype1==0.6.3
 colorama
 tweepy
 beautifulsoup4==4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 JPype1==0.6.3
-colorama
-tweepy
 beautifulsoup4==4.6.0
+colorama
 lxml==4.1.0
+tweepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-JPype1==0.6.3
+JPype1>=0.7.0
 beautifulsoup4==4.6.0
 colorama
 lxml==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 import platform
 from setuptools import find_packages, setup
 
@@ -24,10 +23,7 @@ def requirements():
         with open(os.path.join(os.path.dirname(__file__), reqfile)) as f:
             return f.read().splitlines()
 
-    if sys.version_info >= (3, ):
-        return _openreq('requirements-py3.txt')
-    else:
-        return _openreq('requirements.txt')
+    return _openreq('requirements.txt')
 
 
 about = get_about()


### PR DESCRIPTION
The current JPype version (0.7.0) is sending a warning message as can be seen in #240.
I am suggesting that we keep the automatic conversion of strings for easier migration, but this can surely be modified in the future.

I am also removing `requirements-py3.txt`, since Python 3 is supported by JPype since version 0.6.0.

Resolves #236, #240