### PR TITLE
Add numpy as requirements for jpype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ colorama
 tweepy
 beautifulsoup4==4.6.0
 lxml>=4.1.0
+numpy>=1.6


### PR DESCRIPTION
The following is an error occurring during tests of KoNLPy.
JPype requires numpy, however it is included as `extra_requires`, and is not installed on a clean install.

```
ImportError while importing test module '/Users/lucypark/dev/my/konlpy/test/test_stream_daum.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test/test_stream_daum.py:6: in <module>
    from konlpy.stream.daum import DaumStreamer
konlpy/__init__.py:11: in <module>
    from konlpy.jvm import init_jvm
konlpy/jvm.py:7: in <module>
    import jpype
../../../.pyenv/versions/test/lib/python2.7/site-packages/jpype/__init__.py:17: in <module>
    from ._jpackage import *
../../../.pyenv/versions/test/lib/python2.7/site-packages/jpype/_jpackage.py:19: in <module>
    import _jpype
E   ImportError: numpy.core.multiarray failed to import
```

This PR adds numpy as a dependency of KoNLPy to circumvent this problem.