### PR TITLE
Update mecab install script

### DIFF
--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2014 Lucy Park
+# Copyright 2019 Team KoNLPy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -18,6 +18,7 @@
 python=$(which python)
 os=$(uname)
 
+# Determine OS
 if [ $os == "Linux" ]; then
     echo "Installing MeCab-ko"
 elif [ $os == "Darwin" ]; then
@@ -28,89 +29,100 @@ else
     exit 0
 fi
 
+# Determine sudo
 if hash "sudo" &>/dev/null; then
     sudo="sudo"
 else
     sudo=""
 fi
 
-# install mecab-ko
-cd /tmp
-curl -LO https://bitbucket.org/eunjeon/mecab-ko/downloads/mecab-0.996-ko-0.9.2.tar.gz
-tar zxfv mecab-0.996-ko-0.9.2.tar.gz
-cd mecab-0.996-ko-0.9.2
-./configure
-make
-make check
-$sudo make install
+install_mecab_ko(){
+    cd /tmp
+    curl -LO https://bitbucket.org/eunjeon/mecab-ko/downloads/mecab-0.996-ko-0.9.2.tar.gz
+    tar zxfv mecab-0.996-ko-0.9.2.tar.gz
+    cd mecab-0.996-ko-0.9.2
+    ./configure
+    make
+    make check
+    $sudo make install
+}
 
-# install mecab-ko-dic
-## install requirement automake1.11
-# TODO: if not [automake --version]
-if [ "$os" == "Linux" ]; then
-    if [ "$(grep -Ei 'debian|buntu|mint' /etc/*release)" ]; then
-        $sudo apt-get update && $sudo apt-get install -y automake
-    elif [ "$(grep -Ei 'fedora|redhat' /etc/*release)" ]; then
-        $sudo yum install -y automake
-    else
-        ##
-        # Autoconf
-        #
-        # stage directory
-        builddir=`mktemp -d` && cd $builddir
+install_automake(){
+    ## install requirement automake1.11
+    # TODO: if not [automake --version]
+    if [ "$os" == "Linux" ]; then
+        if [ "$(grep -Ei 'debian|buntu|mint' /etc/*release)" ]; then
+            $sudo apt-get update && $sudo apt-get install -y automake
+        elif [ "$(grep -Ei 'fedora|redhat' /etc/*release)" ]; then
+            $sudo yum install -y automake
+        else
+            ##
+            # Autoconf
+            #
+            # stage directory
+            builddir=`mktemp -d` && cd $builddir
 
-        # download and extract source
-        curl -LO http://ftpmirror.gnu.org/autoconf/autoconf-latest.tar.gz
-        tar -zxvf autoconf-*
+            # download and extract source
+            curl -LO http://ftpmirror.gnu.org/autoconf/autoconf-latest.tar.gz
+            tar -zxvf autoconf-*
 
-        # configure, make, install --prefix=/usr/local
-        cd autoconf*
-        ./configure
-        make
-        $sudo make install
+            # configure, make, install --prefix=/usr/local
+            cd autoconf*
+            ./configure
+            make
+            $sudo make install
 
-        # erase stage dir
-        rm -rf $builddir
+            # erase stage dir
+            rm -rf $builddir
 
 
-        ##
-        # Automake
-        #
-        # stage directory
-        builddir=`mktemp -d` && cd $builddir
+            ##
+            # Automake
+            #
+            # stage directory
+            builddir=`mktemp -d` && cd $builddir
 
-        # download and extract source
-        curl -LO http://ftpmirror.gnu.org/automake/automake-1.11.tar.gz
-        tar -zxvf automake-1.11.tar.gz
+            # download and extract source
+            curl -LO http://ftpmirror.gnu.org/automake/automake-1.11.tar.gz
+            tar -zxvf automake-1.11.tar.gz
 
-        # configure, make, install --prefix=/usr/local
-        cd automake-1.11
-        ./configure
-        make
-        $sudo make install
+            # configure, make, install --prefix=/usr/local
+            cd automake-1.11
+            ./configure
+            make
+            $sudo make install
 
-        # erase stage dir
-        rm -rf $builddir
+            # erase stage dir
+            rm -rf $builddir
+        fi
+
+    elif [ "$os" == "Darwin" ]; then
+        brew install automake
     fi
+}
 
-elif [ "$os" == "Darwin" ]; then
-    brew install automake
-fi
+install_mecab_ko_dic(){
+    cd /tmp
+    curl -LO https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.1.1-20180720.tar.gz
+    tar -zxvf mecab-ko-dic-2.1.1-20180720.tar.gz
+    cd mecab-ko-dic-2.1.1-20180720
+    ./autogen.sh
+    ./configure
+    make
+    $sudo sh -c 'echo "dicdir=/usr/local/lib/mecab/dic/mecab-ko-dic" > /usr/local/etc/mecabrc'
+    $sudo make install
+}
 
-cd /tmp
-curl -LO https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.1.1-20180720.tar.gz
-tar -zxvf mecab-ko-dic-2.1.1-20180720.tar.gz
-cd mecab-ko-dic-2.1.1-20180720
-./autogen.sh
-./configure
-make
-$sudo sh -c 'echo "dicdir=/usr/local/lib/mecab/dic/mecab-ko-dic" > /usr/local/etc/mecabrc'
-$sudo make install
+install_mecab_python(){
+    cd /tmp
+    git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
+    cd mecab-python-0.996
+    $python setup.py build
+    $sudo $python setup.py install
+}
 
-# install mecab-python
-cd /tmp
-git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
-cd mecab-python-0.996
 
-$python setup.py build
-$sudo $python setup.py install
+install_automake
+install_mecab_ko
+install_mecab_ko_dic
+install_mecab_python

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -15,15 +15,15 @@
 # limitations under the License.
 #
 
-python=$(which python)
-os=$(uname)
+# Set mecab related variable(s)
+mecab_dicdir="/usr/local/lib/mecab/dic/mecab-ko-dic"
+
+# Exit as soon as we fail
+set -e
 
 # Determine OS
-if [ $os == "Linux" ]; then
-    echo "Installing MeCab-ko"
-elif [ $os == "Darwin" ]; then
-    echo "Installing MeCab-ko"
-else
+os=$(uname)
+if [[ ! $os == "Linux" ]] && [[ ! $os == "Darwin" ]]; then
     echo "This script does not support this OS."
     echo "Try consulting https://github.com/konlpy/konlpy/blob/master/scripts/mecab.sh"
     exit 0
@@ -122,7 +122,31 @@ install_mecab_python(){
 }
 
 
-install_automake
-install_mecab_ko
-install_mecab_ko_dic
-install_mecab_python
+if ! hash "automake" &>/dev/null; then
+    echo "Installing automake (A dependency for mecab-ko)"
+    install_automake
+fi
+
+if hash "mecab" &>/dev/null; then
+    echo "mecab-ko is already installed"
+else
+    echo "Install mecab-ko-dic"
+    install_mecab_ko
+fi
+
+if [[ -d $mecab_dicdir ]]; then
+    echo "mecab-ko-dic is already installed"
+else
+    echo "Install mecab-ko-dic"
+    install_mecab_ko_dic
+fi
+
+if [[ $(python -c 'import pkgutil; print(1 if pkgutil.find_loader("MeCab") else 0)') == "0" ]]; then
+    echo "mecab-python is already installed"
+else
+    echo "Install mecab-python"
+    install_mecab_python
+fi
+    echo "Using $(which python)"
+
+echo "Done."

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -102,6 +102,7 @@ install_automake(){
 }
 
 install_mecab_ko_dic(){
+    echo "Install mecab-ko-dic"
     cd /tmp
     curl -LO https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.1.1-20180720.tar.gz
     tar -zxvf mecab-ko-dic-2.1.1-20180720.tar.gz
@@ -115,10 +116,10 @@ install_mecab_ko_dic(){
 
 install_mecab_python(){
     cd /tmp
-    git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
-    cd mecab-python-0.996
-    $python setup.py build
-    $sudo $python setup.py install
+    if [[ ! -d "mecab-python-0.996" ]]; then
+        git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
+    fi
+    pip install /tmp/mecab-python-0.996
 }
 
 
@@ -147,6 +148,5 @@ else
     echo "Install mecab-python"
     install_mecab_python
 fi
-    echo "Using $(which python)"
 
 echo "Done."

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -142,7 +142,7 @@ else
     install_mecab_ko_dic
 fi
 
-if [[ $(python -c 'import pkgutil; print(1 if pkgutil.find_loader("MeCab") else 0)') == "0" ]]; then
+if [[ $(python -c 'import pkgutil; print(1 if pkgutil.find_loader("MeCab") else 0)') == "1" ]]; then
     echo "mecab-python is already installed"
 else
     echo "Install mecab-python"

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -115,10 +115,11 @@ install_mecab_ko_dic(){
 }
 
 install_mecab_python(){
-    cd /tmp
+    pushd /tmp
     if [[ ! -d "mecab-python-0.996" ]]; then
         git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
     fi
+    popd
     pip install /tmp/mecab-python-0.996
 }
 

--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -15,8 +15,9 @@
 # limitations under the License.
 #
 
-
+python=$(which python)
 os=$(uname)
+
 if [ $os == "Linux" ]; then
     echo "Installing MeCab-ko"
 elif [ $os == "Darwin" ]; then
@@ -111,11 +112,5 @@ cd /tmp
 git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
 cd mecab-python-0.996
 
-python setup.py build
-$sudo python setup.py install
-
-if hash "python3" &>/dev/null
-then
-    python3 setup.py build
-    $sudo python3 setup.py install
-fi
+$python setup.py build
+$sudo $python setup.py install


### PR DESCRIPTION
The current mecab install script installs the following:

- mecab-ko
- mecab-ko-dic
- mecab-python

However, there were issues where people installed MeCab with the installer, but KoNLPy complained that it does not exist (#228). I am assuming this is due to multiple Python versions and/or virtual environments installed in the system.

This  PR makes a change in the install script, to install `mecab-python` in the environment of the current directory, instead of `/tmp`.

It also makes several further changes, as follows:

- Checks installation before install
- Installs via pip instead of setup.py
- Functionalizes bash commands
- Changes author name to `Team KoNLPy`

Resolves #228.