### PR TITLE
Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,6 @@
 *.settings/
 .cache
 build/
-dist/
-<<<<<<< HEAD
-docs/_build/
-<<<<<<< master
 data/
-=======
-=======
+dist/
 docs/_build/
->>>>>>> parent of 82368b6... update experimental streaming interface from koshort
->>>>>>> Revert "update experimental streaming interface from koshort"


### PR DESCRIPTION
There were the merge-conflicted dividers inside of .gitignore, now removed and sorted.