### PR TITLE
Fix methods for mecab pickling

### DIFF
--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -103,6 +103,7 @@ class Mecab():
         return [s for s, t in tagged if t.startswith('N')]
 
     def __init__(self, dicpath='/usr/local/lib/mecab/dic/mecab-ko-dic'):
+        self.dicpath = dicpath
         try:
             self.tagger = Tagger('-d %s' % dicpath)
             self.tagset = utils.read_json('%s/data/tagset/mecab.json' % utils.installpath)
@@ -114,9 +115,9 @@ class Mecab():
     def __setstate__(self, state):
         """just reinitialize."""
 
-        self.__init__(*state['args'])
+        self.__init__(dicpath=state['dicpath'])
 
     def __getstate__(self):
         """store arguments."""
 
-        return {'args': self.args}
+        return {'dicpath': self.dicpath}


### PR DESCRIPTION
#234 PR에서 피클링을 위해 추가한 메서드에 오류가 있었습니다.
Mecab 클래스를 서브클래싱하여 테스트하고는 무심결에 복사해 커밋을 했네요.
@minhoryang 님이 지적해 주신대로 올바르게 초기화 파라미터를 저장하도록 수정했습니다.

Ubuntu, python 3.7, konlpy v0.5.2rc1, mecab-python 0.996-ko-0.9.2 에서 테스트했습니다.

감사합니다!