### PR TITLE
Fixes #271, Update install.rst, mecab.sh to support Python 3.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,69 +4,68 @@ Installation
 .. note::
 
     For troubleshooting information, see these pages:
-    `Linux <https://github.com/konlpy/konlpy/issues?q=label%3Alinux>`_.
-    `Mac OS <https://github.com/konlpy/konlpy/issues?q=label%3A"mac+os">`_.
-    `Windows <https://github.com/konlpy/konlpy/issues?q=label%3Awindows>`_.
+    `Linux <https://github.com/konlpy/konlpy/issues?q=label%3AOS%2FLinux>`_.
+    `Mac OS <https://github.com/konlpy/konlpy/issues?q=label%3AOS%2FMacOS>`_.
+    `Windows <https://github.com/konlpy/konlpy/issues?q=label%3AOS%2FWindows>`_.
     Please record a `"New Issue" <https://github.com/konlpy/konlpy/issues/new>`_ if you have an error that is not listed.
+
+.. Warning::
+
+    Python 2 End of Life Announced as January 1st 2020.
+
+    This page covers Python 3 only.  The last-known version for Python 2 is v0.5.2, install it via `pip install konlpy==v0.5.2`.
 
 
 Ubuntu
 ------
 
+Supported: Xenial(16.04.3 LTS), Bionic(18.04.3 LTS), Disco(19.04), Eoan(19.10)
+
 1. Install dependencies
 
     .. sourcecode:: bash
 
-        # Install Java 1.7 or up
-        $ sudo apt-get install g++ openjdk-7-jdk python-dev python3-dev
+        # Install Java 1.8 or up
+        $ sudo apt-get install g++ openjdk-8-jdk python3-dev python3-pip curl
 
 2. Install KoNLPy
 
     .. sourcecode:: bash
 
-        $ pip install konlpy        # Python 2.x
-        $ pip3 install konlpy       # Python 3.x
+        $ python3 -m pip install --upgrade pip
+        $ python3 -m pip install konlpy       # Python 3.x
 
 3. Install MeCab (*optional*)
 
     .. sourcecode:: bash
 
-        $ sudo apt-get install curl
+        $ sudo apt-get install curl git
         $ bash <(curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh)
 
 
 CentOS
 ------
 
+Supported: CentOS 7, 8
+
 1. Install dependencies
 
     .. sourcecode:: bash
 
-        $ sudo yum install gcc-c++ java-1.7.0-openjdk-devel python-devel
-
-        $ wget http://peak.telecommunity.com/dist/ez_setup.py               # Python 2.x
-        $ sudo python ez_setup.py
-        $ sudo easy_install pip
-
-        $ wget https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz  # Python 3.x
-        $ tar xf Python-3.* 
-        $ cd Python-3.*
-        $ ./configure
-        $ make # Build
-        $ sudo make altinstall
+        $ sudo yum install gcc-c++ java-1.8.0-openjdk-devel python3 python3-devel python3-pip make diffutils
 
 2. Install KoNLPy
 
     .. sourcecode:: bash
 
-        $ pip install konlpy        # Python 2.x
-        $ pip3.4 install konlpy     # Python 3.x
+        $ python3 -m pip install --upgrade pip
+        $ python3 -m pip install konlpy     # Python 3.x
 
 3. Install MeCab (*optional*)
 
     .. sourcecode:: bash
 
-        $ sudo yum install curl
+        $ sudo yum install curl git
         $ bash <(curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh)
 
 
@@ -77,8 +76,8 @@ Mac OS
 
     .. sourcecode:: bash
 
-       $ pip install konlpy         # Python 2.x
-       $ pip3 install konlpy        # Python 3.x
+       $ python3 -m pip install --upgrade pip
+       $ python3 -m pip install konlpy        # Python 3.x
 
 2. Install MeCab (*optional*)
 

--- a/scripts/Dockerfile.centos:7
+++ b/scripts/Dockerfile.centos:7
@@ -1,0 +1,16 @@
+FROM centos:7
+
+RUN yum update -y
+RUN yum install --assumeyes gcc-c++ python3 python3-devel python3-pip java-1.8.0-openjdk-devel make diffutils
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install konlpy
+
+RUN yum install --assumeyes curl git
+RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash
+
+RUN yum install --assumeyes git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.centos:8
+++ b/scripts/Dockerfile.centos:8
@@ -1,0 +1,16 @@
+FROM centos:8
+
+RUN yum update -y
+RUN yum install --assumeyes gcc-c++ python3 python3-devel python3-pip java-1.8.0-openjdk-devel make diffutils
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install konlpy
+
+RUN yum install --assumeyes curl git
+RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash
+
+RUN yum install --assumeyes git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.template:centos
+++ b/scripts/Dockerfile.template:centos
@@ -1,0 +1,21 @@
+FROM centos:{{ docker_image_version | default('latest') }} AS install_phase
+
+RUN yum update -y
+RUN yum install --assumeyes gcc-c++ python3 python3-devel python3-pip java-1.8.0-openjdk-devel make diffutils
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install {{ konlpy_package_definition | default('konlpy') }}
+
+RUN yum install --assumeyes curl git
+RUN curl -s https://raw.githubusercontent.com/{{ github_repo_mecab | default('konlpy/konlpy') }}/{{ github_branch_mecab | default('master') }}/scripts/mecab.sh | bash
+
+ENTRYPOINT python3
+
+# XXX: Stop Here with `docker build --target install_phase ...`
+FROM install_phase AS test_phase
+
+RUN yum install --assumeyes git
+RUN git clone https://github.com/{{ github_repo_konlpy | default('konlpy/konlpy') }} konlpy.git
+WORKDIR konlpy.git
+RUN git checkout {{ github_branch_konlpy | default('master') }}
+RUN python3 -m pip install -r requirements-dev.txt
+CMD -m pytest -v .

--- a/scripts/Dockerfile.template:ubuntu
+++ b/scripts/Dockerfile.template:ubuntu
@@ -1,0 +1,20 @@
+FROM ubuntu:{{ docker_image_version | default('latest') }} AS install_phase
+
+RUN apt-get update
+
+RUN apt-get install -y g++ openjdk-8-jdk python3-dev python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install {{ konlpy_package_definition | default('konlpy') }}
+
+RUN apt-get install -y curl git
+RUN curl -s https://raw.githubusercontent.com/{{ github_repo_mecab | default('konlpy/konlpy') }}/{{ github_branch_mecab | default('master') }}/scripts/mecab.sh | bash
+
+# XXX: Stop Here with `docker build --target install_phase ...`
+FROM install_phase AS test_phase
+
+RUN apt-get install -y git
+RUN git clone https://github.com/{{ github_repo_konlpy | default('konlpy/konlpy') }} konlpy.git
+WORKDIR konlpy.git
+RUN git checkout {{ github_branch_konlpy | default('master') }}
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.ubuntu:bionic
+++ b/scripts/Dockerfile.ubuntu:bionic
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+RUN apt-get update
+
+RUN apt-get install -y g++ openjdk-8-jdk python3-dev python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install konlpy
+
+RUN apt-get install -y curl git
+RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash
+
+RUN apt-get install -y git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.ubuntu:disco
+++ b/scripts/Dockerfile.ubuntu:disco
@@ -1,0 +1,17 @@
+FROM ubuntu:disco
+
+RUN apt-get update
+
+RUN apt-get install -y g++ openjdk-8-jdk python3-dev python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install konlpy
+
+RUN apt-get install -y curl git
+RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash
+
+RUN apt-get install -y git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.ubuntu:eoan
+++ b/scripts/Dockerfile.ubuntu:eoan
@@ -1,0 +1,17 @@
+FROM ubuntu:eoan
+
+RUN apt-get update
+
+RUN apt-get install -y g++ openjdk-8-jdk python3-dev python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install konlpy
+
+RUN apt-get install -y curl git
+RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash
+
+RUN apt-get install -y git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.ubuntu:xenial
+++ b/scripts/Dockerfile.ubuntu:xenial
@@ -1,0 +1,17 @@
+FROM ubuntu:xenial
+
+RUN apt-get update
+
+RUN apt-get install -y g++ openjdk-8-jdk python3-dev python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install konlpy
+
+RUN apt-get install -y curl git
+RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash
+
+RUN apt-get install -y git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.ubuntu:xenial-testpypi
+++ b/scripts/Dockerfile.ubuntu:xenial-testpypi
@@ -1,0 +1,16 @@
+FROM ubuntu:xenial
+
+RUN apt-get update
+
+RUN apt-get install -y g++ openjdk-8-jdk python3-dev python3-pip
+RUN python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ konlpy==0.5.2-rc.2
+
+RUN apt-get install -y curl git
+RUN curl -s https://raw.githubusercontent.com/minhoryang/konlpy/issues/271/scripts/mecab.sh | bash
+
+RUN apt-get install -y git
+RUN git clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+RUN git checkout master
+RUN python3 -m pip install -r requirements-dev.txt
+CMD python3 -m pytest -v .

--- a/scripts/Dockerfile.windows:10
+++ b/scripts/Dockerfile.windows:10
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/windows:1809
+
+# Install Chocolatey
+RUN @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+
+# New Powershell, so choco is available
+SHELL ["powershell"]
+
+# Choco disable upload progress
+RUN choco feature disable --name showDownloadProgress
+
+# python 3.
+RUN choco install -y python3
+RUN py -m pip install --upgrade pip
+
+# Jpype requires: (and respect caching)
+RUN choco install -y vcbuildtools  # XXX: so long...
+RUN choco install -y adoptopenjdk11 --version 11.0.5.10  # XXX: version fixed for JAVA_HOME.
+ENV JAVA_HOME "C:\\Program Files\\AdoptOpenJDK\\jdk-11.0.5.10-hotspot"
+
+# TestEnv
+RUN choco install -y git.install
+RUN & 'C:\Program Files\Git\bin\git.exe' clone https://github.com/konlpy/konlpy konlpy.git
+WORKDIR konlpy.git
+
+RUN & 'C:\Program Files\Git\bin\git.exe' checkout master
+RUN py -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ konlpy==0.5.2-rc.2
+RUN py -m pip install -r .\requirements-dev.txt
+CMD py -m pytest -v .


### PR DESCRIPTION
- Update install.rst:
    - Added Python 2 Warning
    - Update dependencies (JDK7->8)
- Update mecab.sh:
    - Use Python 3
    - Update dependencies
    - Add warning for brew
    - Store python packages accordingly between system and user space.
- Added Dockerfiles for testing the installation process
 