### PR TITLE
Fix #295 with assertion warning for phrase input

### DIFF
--- a/konlpy/tag/_common.py
+++ b/konlpy/tag/_common.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+""" Common utility function for tagger classes """
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+def validate_phrase_inputs(phrase):
+    """validate if phrase input is provided in str format
+
+    Args:
+        phrase (str): phrase input
+    """
+    msg = "phrase input should be string, not %s" % type(phrase)
+    assert isinstance(phrase, str), msg

--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -7,6 +7,7 @@ import re
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Hannanum']
@@ -83,6 +84,7 @@ class Hannanum():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         if ntags == 9:
             result = self.jhi.simplePos09(phrase)

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -5,6 +5,7 @@ import re
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Kkma']
@@ -51,6 +52,7 @@ class Kkma():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         sentences = self.jki.morphAnalyzer(phrase)
         morphemes = []

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -6,6 +6,7 @@ import os
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Komoran']
@@ -56,6 +57,7 @@ class Komoran():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         sentences = phrase.split('\n')
         morphemes = []

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -9,6 +9,7 @@ except ImportError:
     pass
 
 from konlpy import utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Mecab']
@@ -74,6 +75,7 @@ class Mecab():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         if sys.version_info[0] < 3:
             phrase = phrase.encode('utf-8')

--- a/konlpy/tag/_okt.py
+++ b/konlpy/tag/_okt.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 def Twitter(jvmpath=None):
@@ -56,6 +57,7 @@ class Okt():
         :param stem: If True, stem tokens.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         tokens = self.jki.tokenize(
                     phrase,


### PR DESCRIPTION
#295 이슈에서 제기된 문제로, tagger 클래스들의 .pos method를 사용할 때 사용자들이 올바른 입력을 넣었는지 확인할 수 없는 부분을 assertion 오류를 통해서 개선합니다.