### PR TITLE
Fix #295 with assertion warning for phrase input #320

### DIFF
--- a/konlpy/tag/_common.py
+++ b/konlpy/tag/_common.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+""" Common utility function for tagger classes """
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+def validate_phrase_inputs(phrase):
+    """validate if phrase input is provided in str format
+
+    Args:
+        phrase (str): phrase input
+    """
+    msg = "phrase input should be string, not %s" % type(phrase)
+    assert isinstance(phrase, str), msg

--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -84,7 +84,7 @@ class Hannanum():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
-        validate_phrase_inputs()
+        validate_phrase_inputs(phrase)
 
         if ntags == 9:
             result = self.jhi.simplePos09(phrase)

--- a/konlpy/tag/_hannanum.py
+++ b/konlpy/tag/_hannanum.py
@@ -7,6 +7,7 @@ import re
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Hannanum']
@@ -83,6 +84,7 @@ class Hannanum():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         if ntags == 9:
             result = self.jhi.simplePos09(phrase)

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -5,6 +5,7 @@ import re
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Kkma']
@@ -51,6 +52,7 @@ class Kkma():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         sentences = self.jki.morphAnalyzer(phrase)
         morphemes = []

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -52,7 +52,7 @@ class Kkma():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
-        validate_phrase_inputs()
+        validate_phrase_inputs(phrase)
 
         sentences = self.jki.morphAnalyzer(phrase)
         morphemes = []

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -6,6 +6,7 @@ import os
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Komoran']
@@ -56,6 +57,7 @@ class Komoran():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         sentences = phrase.split('\n')
         morphemes = []

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -57,7 +57,7 @@ class Komoran():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
-        validate_phrase_inputs()
+        validate_phrase_inputs(phrase)
 
         sentences = phrase.split('\n')
         morphemes = []

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -9,6 +9,7 @@ except ImportError:
     pass
 
 from konlpy import utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 __all__ = ['Mecab']
@@ -74,6 +75,7 @@ class Mecab():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         if sys.version_info[0] < 3:
             phrase = phrase.encode('utf-8')

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -75,7 +75,7 @@ class Mecab():
         :param flatten: If False, preserves eojeols.
         :param join: If True, returns joined sets of morph and tag.
         """
-        validate_phrase_inputs()
+        validate_phrase_inputs(phrase)
 
         if sys.version_info[0] < 3:
             phrase = phrase.encode('utf-8')

--- a/konlpy/tag/_okt.py
+++ b/konlpy/tag/_okt.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import jpype
 
 from konlpy import jvm, utils
+from konlpy.tag._common import validate_phrase_inputs
 
 
 def Twitter(jvmpath=None):
@@ -56,6 +57,7 @@ class Okt():
         :param stem: If True, stem tokens.
         :param join: If True, returns joined sets of morph and tag.
         """
+        validate_phrase_inputs()
 
         tokens = self.jki.tokenize(
                     phrase,

--- a/konlpy/tag/_okt.py
+++ b/konlpy/tag/_okt.py
@@ -57,7 +57,7 @@ class Okt():
         :param stem: If True, stem tokens.
         :param join: If True, returns joined sets of morph and tag.
         """
-        validate_phrase_inputs()
+        validate_phrase_inputs(phrase)
 
         tokens = self.jki.tokenize(
                     phrase,

--- a/test/test_hannanum.py
+++ b/test/test_hannanum.py
@@ -78,3 +78,9 @@ def test_hannanum_pos_join(hannanum_instance, string):
          u'\uac00/P',
          u'\uc790/E',
          u'!/S']
+
+def test_hannanum_typechecking(hannanum_instance):
+    try:
+        hannanum_instance.pos([])
+    except AssertionError:
+        pass

--- a/test/test_kkma.py
+++ b/test/test_kkma.py
@@ -46,3 +46,9 @@ def test_kkma_pos_join(kkma_instance, string):
 def test_kkma_sentences(kkma_instance, string):
     assert kkma_instance.sentences(string) ==\
         [u'\uaf43\uac00\ub9c8 \ud0c0\uace0 \uac15\ub0a8 \uac00\uc790!']
+
+def test_kkma_typechecking(kkma_instance):
+    try:
+        kkma_instance.pos([])
+    except AssertionError:
+        pass

--- a/test/test_komoran.py
+++ b/test/test_komoran.py
@@ -48,3 +48,9 @@ else:
     def test_komoran_morphs(komoran_instance, string):
         assert komoran_instance.morphs(string) ==\
             [u'\uaf43\uac00\ub9c8', u'\ud0c0', u'\uace0', u'\uac15\ub0a8', u'\uac00', u'\uc790', u'!']
+
+    def test_komoran_typechecking(komoran_instance):
+        try:
+            komoran_instance.pos([])
+        except AssertionError:
+            pass

--- a/test/test_mecab.py
+++ b/test/test_mecab.py
@@ -47,3 +47,9 @@ def test_mecab_morphs(mecab_instance, string):
 def test_mecab_nouns(mecab_instance, string):
     assert mecab_instance.nouns(string) ==\
         [u'\uaf43\uac00\ub9c8', u'\uac15\ub0a8']
+
+def test_mecab_typechecking(mecab_instance):
+    try:
+        mecab_instance.pos([])
+    except AssertionError:
+        pass

--- a/test/test_openkoreantext.py
+++ b/test/test_openkoreantext.py
@@ -52,3 +52,9 @@ def test_tkorean_morphs(tkorean_instance, string):
 def test_tkorean_normalize(tkorean_instance, string):
     assert tkorean_instance.normalize(string) ==\
         u'\uaf43\uac00\ub9c8 \ud0c0\uace0 \uac15\ub0a8 \uac00\ub098\uc694\u314b\u314b\u314b'
+
+def test_tkorean_typechecking(tkorean_instance):
+    try:
+        tkorean_instance.pos([])
+    except AssertionError:
+        pass


### PR DESCRIPTION
#295 이슈에서 제기된 문제로, tagger 클래스들의 .pos method를 사용할 때 사용자들이 올바른 입력을 넣었는지 확인할 수 없는 부분을 assertion 오류를 통해서 개선합니다.

Example:
```python
>>> tagger.pos([])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/daunjung/GitHub/konlpy/konlpy/tag/_okt.py", line 60, in pos
    validate_phrase_inputs(phrase)
  File "/Users/daunjung/GitHub/konlpy/konlpy/tag/_common.py", line 14, in validate_phrase_inputs
    assert isinstance(phrase, str), msg
AssertionError: phrase input should be string, not <class 'list'>
>>> tagger.pos("asdf")
[('asdf', 'Alpha')]
```