### PR TITLE
Fix #309 to pass `make check`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include requirements.txt
+include requirements.txt requirements2.txt
 recursive-include konlpy/data *
 recursive-include konlpy/java *.class *.jar *.json
 recursive-include konlpy/java/data *

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,13 @@ check:
 	--ignore-bad-ideas *.mo
 
 	pyroma dist/konlpy-*tar.gz
-	pep8 --ignore=E501 konlpy/*.py
-	pep8 --ignore=E501 konlpy/*/*.py
+
+	# E126: Continuation line over-indented
+	# E402: Module level import not at top of file
+	# E501: Line too long
+	# E701: Multiple statements on one line(colon)
+	pep8 --ignore=E501,E402 konlpy/*.py
+	pep8 --ignore=E501,E701,E126 konlpy/*/*.py
 
 testpypi:
 	python setup.py register -r pypitest

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,12 @@ build:
 	python setup.py sdist --formats=gztar,zip
 
 check:
-	check-manifest
+	check-manifest \
+	--ignore \
+	.gitmodules,CONTRIBUTING*,LICENSE,Makefile,build.xml,pypirc.sample,reinstall,requirements-dev.txt,\
+	docs/**,konlpy/java/src/**,scripts/** \
+	--ignore-bad-ideas *.mo
+
 	pyroma dist/konlpy-*tar.gz
 	pep8 --ignore=E501 konlpy/*.py
 	pep8 --ignore=E501 konlpy/*/*.py

--- a/konlpy/data.py
+++ b/konlpy/data.py
@@ -207,6 +207,6 @@ class StringWriter(object):
 
 
 __all__ = [
-    'find', 'load', 'listdir', 'clear', 
+    'find', 'load', 'listdir', 'clear',
     'path', 'FileSystemPathPointer', 'PathPointer',
-    'CorpusReader', 'StringWriter',]
+    'CorpusReader', 'StringWriter']

--- a/konlpy/tag/_okt.py
+++ b/konlpy/tag/_okt.py
@@ -92,7 +92,7 @@ class Okt():
         """Phrase extractor."""
 
         return [p for p in self.jki.phrases(phrase).toArray()]
-    
+
     def normalize(self, phrase):
         text = self.jki.normalize(phrase)
         return text


### PR DESCRIPTION
저도 #309 와 같은 이슈가 생겨서 수정 사항을 제안해봅니다.

1. requirements2.txt를 MANIFEST.in에 추가
파이썬2로 konlpy를 설치하려면 requirements2.txt가 패키지에 포함되어야 할 거 같습니다.

2. check-manifest --ignore 옵션 추가
`check-manifest`가 git의 파일들과 소스 distribution 파일들의 같은지 비교하는 것 같습니다.
소스 distribution에 없어도 되는 git의 파일들을 무시하도록 지정했습니다.

3. pep8 스타일 가이드대로 수정
사소한 것들은 수정했고,
몇 가지는 코드를 놔둔 채 가이드를 무시하도록 룰을 추가했습니다.
