### PR TITLE
Add feature(#232) to split Inflect type words of mecab

### DIFF
--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -29,10 +29,10 @@ attrs = ['tags',        # 품사 태그
 def parse(result, allattrs=False, join=False, split_inflect=False):
     def split(elem, join=False, split_inflect=False) -> []:
         if not elem: return [('', 'SY')]
-        splited = elem.split('\t', 1)
-        if len(splited) != 2:
+        segments = elem.split('\t', 1)
+        if len(segments) != 2:
             return [('', 'SY')]
-        s, t = splited
+        s, t = segments
         features = t.split(',')
 
         if split_inflect and features[4] == 'Inflect':

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -28,10 +28,12 @@ attrs = ['tags',        # 품사 태그
 
 def parse(result, allattrs=False, join=False, split_inflect=False):
     def split(elem, join=False, split_inflect=False):
+        print("elem", elem)
         if not elem: return ('', 'SY')
         splited = elem.split('\t', 1)
         if len(splited) != 2:
-            return ('', 'SY')
+            print("return (``, SY)")
+            return [('', 'SY')]
         s, t = splited
         features = t.split(',')
 
@@ -52,6 +54,7 @@ def parse(result, allattrs=False, join=False, split_inflect=False):
             if join:
                 return [s + '/' + tag]
             else:
+                print("return", [(s, tag)])
                 return [(s, tag)]
 
     if split_inflect:
@@ -135,6 +138,7 @@ class Mecab():
         else:
             if flatten:
                 result = self.tagger.parse(phrase)
+                print("result", result)
                 return parse(result, join=join, split_inflect=split_inflect)
             else:
                 return [parse(self.tagger.parse(eojeol), join=join, split_inflect=split_inflect)
@@ -142,7 +146,7 @@ class Mecab():
 
     def morphs(self, phrase):
         """Parse phrase to morphemes."""
-
+        print("self.pos: ", self.pos(phrase))
         return [s for s, t in self.pos(phrase)]
 
     def nouns(self, phrase):

--- a/konlpy/tag/_mecab.py
+++ b/konlpy/tag/_mecab.py
@@ -27,12 +27,10 @@ attrs = ['tags',        # 품사 태그
 
 
 def parse(result, allattrs=False, join=False, split_inflect=False):
-    def split(elem, join=False, split_inflect=False):
-        print("elem", elem)
-        if not elem: return ('', 'SY')
+    def split(elem, join=False, split_inflect=False) -> []:
+        if not elem: return [('', 'SY')]
         splited = elem.split('\t', 1)
         if len(splited) != 2:
-            print("return (``, SY)")
             return [('', 'SY')]
         s, t = splited
         features = t.split(',')
@@ -54,7 +52,6 @@ def parse(result, allattrs=False, join=False, split_inflect=False):
             if join:
                 return [s + '/' + tag]
             else:
-                print("return", [(s, tag)])
                 return [(s, tag)]
 
     if split_inflect:
@@ -138,7 +135,6 @@ class Mecab():
         else:
             if flatten:
                 result = self.tagger.parse(phrase)
-                print("result", result)
                 return parse(result, join=join, split_inflect=split_inflect)
             else:
                 return [parse(self.tagger.parse(eojeol), join=join, split_inflect=split_inflect)
@@ -146,7 +142,7 @@ class Mecab():
 
     def morphs(self, phrase):
         """Parse phrase to morphemes."""
-        print("self.pos: ", self.pos(phrase))
+
         return [s for s, t in self.pos(phrase)]
 
     def nouns(self, phrase):


### PR DESCRIPTION
예전에 제가 제기했던 이슈 #232 를 구현하여 PR 드립니다.

-------------------------------------------------------------------------------------------------
#### 목표 :
현재 konlpy.tag의 Mecab을 불러와서 형태소 분석을 하면
'힘든 하루였다'란 문장을
`[('힘든', 'VA+ETM'), ('하루', 'NNG'), ('였', 'VCP+EP'), ('다', 'EC')]`
이렇게 표기합니다.

이를 
`[('힘들', 'VA'), ('ㄴ', 'ETM'), ('하루', 'NNG'), ('이', 'VCP'), ('었', 'EP'), ('다', 'EC')]`
로 볼 수 있는 옵션을 추가했습니다.

**`mecab.pos('힘든 하루였다', split_inflect=True)`**

-------------------------------------------------------------------------------------------------
#### 구현:
mecab에서 이미  inflect type 단어를 형태소로 나누어 따로 표기해줍니다.

```
힘든	VA+ETM,*,T,힘든,Inflect,VA,ETM,힘들/VA/*+ᆫ/ETM/*
하루	NNG,*,F,하루,*,*,*,*
였	VCP+EP,*,T,였,Inflect,VCP,EP,이/VCP/*+었/EP/*
다	EC,*,F,다,*,*,*,*
```

그래서 필요한 부분을 추출해서 썼습니다.