### PR TITLE
Fix: Amazon Linux os error handling

### DIFF
--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -143,7 +143,11 @@ install_mecab_ko_dic(){
     ./configure
     if [[ $os == "Linux" ]]; then
         mecab-config --libs-only-L | $sudo tee /etc/ld.so.conf.d/mecab.conf  # XXX: Resolve #271, #182, #133
-        $sudo ldconfig
+        
+        check_amazon=$(cat /etc/system-release) # Check Amazon Linux os
+        if [[ $check_amazon != "Amazon Linux release 2 (Karoo)" ]]; then
+            $sudo ldconfig
+        fi
     fi
     make
     $sudo sh -c 'echo "dicdir=/usr/local/lib/mecab/dic/mecab-ko-dic" > /usr/local/etc/mecabrc'


### PR DESCRIPTION
안녕하세요

aws lambda에 docker을 사용하여 konly와 mecab을 설치하는 과정에 
`ldconfig: command not found`에러가 발생하여 `Amazon Linux`를 예외 처리 하는 구문을 추가하여 PR올립니다.

# 사용한 docker image
- [amazon/aws-lambda-python:3.8](https://hub.docker.com/layers/amazon/aws-lambda-python/3.8/images/sha256-8cabc6882ee7bd1df2f245e9f2f980369bf1281fc52cf0261676a371ca1074ff?context=explore)

# 관련 이슈 번호
- #378  

✅ Closes: #378 