### PR TITLE
Add CFLAGS for clang to handle C++

### DIFF
--- a/scripts/mecab.sh
+++ b/scripts/mecab.sh
@@ -156,7 +156,7 @@ install_mecab_python(){
         git clone https://bitbucket.org/eunjeon/mecab-python-0.996.git
     fi
     popd
-    $python -m pip install $at_user_site /tmp/mecab-python-0.996
+    CFLAGS=-stdlib=libc++ $python -m pip install $at_user_site /tmp/mecab-python-0.996
 }
 
 


### PR DESCRIPTION
Mecab fails to install on MacOS due to lack of clang flags.

```
#include <stdexcept>
         ^~~~~~~~~~~
1 error generated.
error: command 'gcc' failed with exit status 1
```

Changed the install script to add appropriate `CFLAGS`.