### PR TITLE
Fixes #404 by migrating to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: KoNLPy CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: before_install
+        run: |
+          pip install -r requirements.txt
+          pip install coveralls
+          pip install pytest-cov
+
+      - name: install
+        run: python setup.py -q install
+
+      - name: after_success
+        env: 
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: coveralls
+
+      - name: script
+        run: |
+          coverage run --source=konlpy -m pytest -k 'not (komoran or mecab)'


### PR DESCRIPTION
Addressing Issue #404 , I've migrated the Travic CI .yml file to GitHub Actions. Build for Python 2.7 has been removed due to lack of support for Python 2 from GitHub Actions (for reference, see [Issue #672](https://github.com/actions/setup-python/issues/672)).

The CI is able to [run successfully](https://github.com/andrewwkimm/konlpy/actions/workflows/ci.yaml).